### PR TITLE
Hana Tests

### DIFF
--- a/Billing.API/Startup.cs
+++ b/Billing.API/Startup.cs
@@ -35,10 +35,10 @@ namespace Billing.API
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
+            //if (env.IsDevelopment())
+            //{
+            app.UseDeveloperExceptionPage();
+            //}
 
             app.UseStaticFiles();
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 COPY --from=publish /app/publish .
+COPY ./libadonetHDB.dll .
 ARG version=unknown
 RUN echo $version > /app/wwwroot/version.txt
 ENTRYPOINT ["dotnet", "Billing.API.dll"]


### PR DESCRIPTION
### Background

Calling the dll from Linux was throwing an error that `libadonetHDB.dll` is required

### Changes

- Added `libadonetHDB.dll` into the solution and modified the Dockerfile in order to copy it to the application directory inside the container.
- Removed the condition `IsDevelopment` so the errors are thrown directly to the client