### PR TITLE
🚧 WIP - Generate Windows Docker Image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,24 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+
+jobs:
+
+  verify:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build --file Dockerfile.verify .
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hi team, the final step of this PR will be generating Windows Docker images on the build process.

But it will be a long way, because (if I am not wrong) it is not possible to generate Windows images with Linux, we will probably need to use a different CI Server, maybe GitHub Actions could work.

By the moment, this PR is only to test, I will let you know when it is ready to review.