### PR TITLE
DAT-79 - Build and publish Windows-based images using GitHub Actions

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,0 +1,27 @@
+name: Build and publish Windows-based Docker image
+
+on:
+
+  pull_request:
+
+jobs:
+
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Verify code format (Linux Docker required)
+      run: docker build --target verify-format --file Dockerfile.verify .
+    - name: Verify .sh files (Linux Docker required)
+      run: docker build --target verify-sh --file Dockerfile.verify .
+
+  build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Restore
+      run: docker build --target restore .
+    - name: Build
+      run: docker build --target build .
+    - name: Test
+      run: docker build --target test .

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -2,6 +2,11 @@ name: Build and publish Windows-based Docker image
 
 on:
 
+  push:
+    branches:
+      - master
+      - INT
+      - PRODTEST
   pull_request:
 
 jobs:
@@ -26,8 +31,27 @@ jobs:
     - name: Test
       run: docker build --target test .
     - name: Publish pre-release image from pull request
+      if: ${{ github.event_name == 'pull_request' }}
       env:
         DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       # By the moment it is building the merge commit, so github.sha is not a commit in the PR branch
       run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=pr-${{ github.event.number }} --platform=windows
+    - name: Publish pre-release image from PRODTEST
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/PRODTEST' }}
+      env:
+        DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=PRODTEST --platform=windows
+    - name: Publish pre-release image from INT
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/INT' }}
+      env:
+        DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=INT --platform=windows
+    - name: Publish pre-release image from master
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=master --platform=windows

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -25,3 +25,9 @@ jobs:
       run: docker build --target build .
     - name: Test
       run: docker build --target test .
+    - name: Publish pre-release image from pull request
+      env:
+        DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # By the moment it is building the merge commit, so github.sha is not a commit in the PR branch
+      run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=pr-${{ github.event.number }} --platform=windows

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -7,6 +7,8 @@ on:
       - master
       - INT
       - PRODTEST
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
 
 jobs:
@@ -55,3 +57,10 @@ jobs:
         DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       run: bash ./build-n-publish.sh --commit=${{ github.sha }} --name=master --platform=windows
+    - name: Publish final image from version tag
+      if: ${{ github.event_name == 'push' && startsWith(github.ref,'refs/tags/v') }}
+      env:
+        DOCKER_WRITTER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKER_WRITTER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        GIT_REF: ${{ github.ref }}
+      run: bash ./build-n-publish.sh --commit=${{ github.sha }} --platform=windows

--- a/README.md
+++ b/README.md
@@ -5,7 +5,17 @@ invoices PDF.
 
 ## Continuous Deployment to test and production environments
 
-We are following the same criteria than [DopplerForms](https://github.com/MakingSense/doppler-forms/blob/master/README.md#continuous-deployment-to-test-and-production-environments).
+We are following the same criteria than
+[DopplerForms](https://github.com/MakingSense/doppler-forms/blob/master/README.md#continuous-deployment-to-test-and-production-environments).
+
+But, since this project should be run on Windows containers, we are also
+building and publishing this using GitHub Actions.
+
+Docker Hub credentials are stored in the [FromDoppler's organization
+secret](https://github.com/organizations/FromDoppler/settings/secrets)
+`DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD`.
+
+GitHub Actions only run build process in PRs from branches in the main fork.
 
 ## API draft
 

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -6,6 +6,11 @@ version=""
 versionPre=""
 platform="linux"
 
+if [ -n "${GIT_REF}" ]
+then
+  version="${GIT_REF#refs/tags/}"
+fi
+
 print_help () {
     echo ""
     echo "Usage: sh build-n-publish.sh [OPTIONS]"
@@ -15,7 +20,7 @@ print_help () {
     echo "Options:"
     echo "  -c, --commit (mandatory)"
     echo "  -n, --name"
-    echo "  -v, --version"
+    echo "  -v, --version (or set GIT_REF environment variable, ie: '/refs/tags/v0.0.14')"
     echo "  -s, --pre-version-suffix (optional, only with version)"
     echo "  -p, --platform (optional, default linux)"
     echo "  -h, --help"


### PR DESCRIPTION
Hi @FromDoppler/sap, @FromDoppler/doppler-melmac and @elsupergomez, 

~~It is another step in having our Windows-based Docker images.~~

~~This runs CI process in each PR. And also render context information in the _pushes_ to `master`, `INT`, `PRODTEST`, and _tags_, it will allow us to learn how to configure CI for those scenarios.~~

Well, finally this PR completes (by the moment) the generation of Windows-based docker images for pre-release (PRs and special branches) and release (tags).

Could you review it?

![image](https://user-images.githubusercontent.com/1157864/92024812-0c156600-ed35-11ea-98e6-2dfd9b3f5628.png)

![image](https://user-images.githubusercontent.com/1157864/92116152-d5d5f600-edc9-11ea-91cc-09879e1a4e6e.png)

![image](https://user-images.githubusercontent.com/1157864/92115223-7e835600-edc8-11ea-9741-a124ac7f0b52.png)
