### PR TITLE
[DAT-75] Fix dummy data

### DIFF
--- a/Billing.API/Services/Invoice/DummyInvoiceService.cs
+++ b/Billing.API/Services/Invoice/DummyInvoiceService.cs
@@ -39,7 +39,7 @@ namespace Billing.API.Services.Invoice
                 DateTime.Today,
                 "ARS",
                 100,
-                $"valid_path_{x}")
+                $"111111/invoice/invoice_2020-09-03_198.pdf")
             ).ToList();
 
             var paginatedInvoices = invoices;


### PR DESCRIPTION
# Background
Update dummy data to download invoices in test environments, the link of the invoices should be accepted by regular expression in the controller `@"^invoice_\d{4}-\d{2}-\d{2}_(\d+)\.pdf$"`

https://github.com/FromDoppler/doppler-billing-api/blob/master/Billing.API/Controllers/InvoiceController.cs#L14

Could you review it?
