### PR TITLE
DAT-101 - version.txt in Windows images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,4 @@ ASALocalRun/
 healthchecksdb
 .DS_Store
 docs/demo-cd-branches/dist
+wwwroot_extras/version.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,5 @@ EXPOSE 80
 EXPOSE 443
 COPY --from=publish /app/publish .
 COPY ./libadonetHDB.dll .
-ARG version=unknown
-RUN echo $version > /app/wwwroot/version.txt
+COPY ./wwwroot_extras/ /app/wwwroot/
 ENTRYPOINT ["dotnet", "Billing.API.dll"]

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -192,9 +192,10 @@ then
       .
 fi
 
+echo "${versionFull}-${platform}" > wwwroot_extras/version.txt
+
 docker build \
     -t "${imageName}:${canonicalTag}${platformSufix}" \
-    --build-arg version="${versionFull}-${platform}" \
     .
 
 # TODO: It could break concurrent deployments with different docker accounts

--- a/wwwroot_extras/note.txt
+++ b/wwwroot_extras/note.txt
@@ -1,0 +1,7 @@
+This file is here to ensure existence and content of `wwwroot_extras` folder and
+allow running `docker build .` without errors.
+
+`build-n-publish.sh` generates a `version.txt` file with the right version
+number and stores it in this folder and is copied to the container during
+`docker build .`.
+


### PR DESCRIPTION
Hi @FromDoppler/doppler-melmac and @FromDoppler/sap,

This is because the line `RUN echo $version > /app/wwwroot/version.txt` was not working fine on Windows with `cmd` and it was generating an empty _version.txt_ file.

It fixes the issue:

![image](https://user-images.githubusercontent.com/1157864/92971060-25659300-f456-11ea-8ce9-9d1af0ce1cda.png)
