### PR TITLE
Adding the secrets file for Windows/Linux docker containers

### DIFF
--- a/Billing.API/Program.cs
+++ b/Billing.API/Program.cs
@@ -36,6 +36,14 @@ namespace Billing.API
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config.AddJsonFile("appsettings.Secret.json", true);
+                    config.AddJsonFile("C:\\ProgramData\\Docker\\secrets\\appsettings.Secret.json", true);
+                    config.AddJsonFile("/run/secrets/appsettings.Secret.json", true);
+                    config.AddKeyPerFile("C:\\ProgramData\\Docker\\secrets", true);
+                    config.AddKeyPerFile("/run/secrets", true);
+                })
                 .UseStartup<Startup>();
     }
 }


### PR DESCRIPTION
### Background

Since this API will be using a Windows container, the logic for secrets files need to support both, Linux/Windows.
Currently not using secrets, but in case we need to, it won't work.

### Changes

Added the lines to add the Secret.json for both types of containers