### PR TITLE
[DAT-111] Implement sorting in the invoices list endpoint

### DIFF
--- a/Billing.API.Test/InvoiceApiTest.cs
+++ b/Billing.API.Test/InvoiceApiTest.cs
@@ -7,6 +7,8 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Billing.API.Models;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Billing.API.Test
@@ -98,6 +100,147 @@ namespace Billing.API.Test
                 _httpTest.ShouldNotHaveMadeACall();
 
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task GetInvoices_WhenDummyDataIsTrue_Should_Sort_By_Product_Asc_When_OrderAsc_is_not_Passed_As_Parameter()
+        {
+            // Arrange
+            using (var appFactory = _factory.WithBypassAuthorization())
+            {
+                appFactory.AddConfiguration(new Dictionary<string, string>
+                {
+                    ["Invoice:UseDummyData"] = "true"
+                });
+
+                var client = appFactory.CreateClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/accounts/doppler/1/invoices?sortColumn=Product");
+
+                // Act
+                var response = await client.SendAsync(request);
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<PaginatedResult<InvoiceListItem>>(content);
+
+                // Assert
+                _httpTest.ShouldNotHaveMadeACall();
+
+                Assert.Collection(result.Items,
+                    invoice1 => Assert.Equal("Prod 1", invoice1.Product),
+                    invoice2 => Assert.Equal("Prod 10", invoice2.Product),
+                    invoice3 => Assert.Equal("Prod 11", invoice3.Product),
+                    invoice4 => Assert.Equal("Prod 12", invoice4.Product),
+                    invoice5 => Assert.Equal("Prod 13", invoice5.Product),
+                    invoice6 => Assert.Equal("Prod 14", invoice6.Product),
+                    invoice7 => Assert.Equal("Prod 15", invoice7.Product),
+                    invoice8 => Assert.Equal("Prod 16", invoice8.Product),
+                    invoice9 => Assert.Equal("Prod 17", invoice9.Product),
+                    invoice10 => Assert.Equal("Prod 18", invoice10.Product));
+            }
+        }
+
+        [Fact]
+        public async Task GetInvoices_WhenDummyDataIsTrue_Should_Sort_By_Product_Desc_When_OrderAsc_is_False()
+        {
+            // Arrange
+            using (var appFactory = _factory.WithBypassAuthorization())
+            {
+                appFactory.AddConfiguration(new Dictionary<string, string>
+                {
+                    ["Invoice:UseDummyData"] = "true"
+                });
+
+                var client = appFactory.CreateClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/accounts/doppler/1/invoices?sortColumn=Product&sortAsc=false");
+
+                // Act
+                var response = await client.SendAsync(request);
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<PaginatedResult<InvoiceListItem>>(content);
+
+                // Assert
+                _httpTest.ShouldNotHaveMadeACall();
+
+                Assert.Collection(result.Items,
+                    invoice1 => Assert.Equal("Prod 9", invoice1.Product),
+                    invoice2 => Assert.Equal("Prod 8", invoice2.Product),
+                    invoice3 => Assert.Equal("Prod 7", invoice3.Product),
+                    invoice4 => Assert.Equal("Prod 6", invoice4.Product),
+                    invoice5 => Assert.Equal("Prod 50", invoice5.Product),
+                    invoice6 => Assert.Equal("Prod 5", invoice6.Product),
+                    invoice7 => Assert.Equal("Prod 49", invoice7.Product),
+                    invoice8 => Assert.Equal("Prod 48", invoice8.Product),
+                    invoice9 => Assert.Equal("Prod 47", invoice9.Product),
+                    invoice10 => Assert.Equal("Prod 46", invoice10.Product));
+            }
+        }
+
+        [Fact]
+        public async Task GetInvoices_WhenDummyDataIsTrue_Should_Sort_By_Default_When_sortColumn_And_sortAsc_Are_Empty()
+        {
+            // Arrange
+            using (var appFactory = _factory.WithBypassAuthorization())
+            {
+                appFactory.AddConfiguration(new Dictionary<string, string>
+                {
+                    ["Invoice:UseDummyData"] = "true"
+                });
+
+                var client = appFactory.CreateClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/accounts/doppler/1/invoices?pageSize=2");
+
+                // Act
+                var response = await client.SendAsync(request);
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<PaginatedResult<InvoiceListItem>>(content);
+
+                // Assert
+                _httpTest.ShouldNotHaveMadeACall();
+
+                Assert.Equal(2, result.Items.Count);
+                Assert.Collection(result.Items,
+                    invoice1 => Assert.Equal("CD0000000000001", invoice1.AccountId),
+                    invoice2 => Assert.Equal("CD0000000000001", invoice2.AccountId));
+            }
+        }
+
+        [Fact]
+        public async Task GetInvoices_WhenDummyDataIsTrue_Should_Sort_By_Product_Asc_When_Page_is_2()
+        {
+            // Arrange
+            using (var appFactory = _factory.WithBypassAuthorization())
+            {
+                appFactory.AddConfiguration(new Dictionary<string, string>
+                {
+                    ["Invoice:UseDummyData"] = "true"
+                });
+
+                var client = appFactory.CreateClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/accounts/doppler/1/invoices?page=2&sortColumn=Product&sortAsc=true");
+
+                // Act
+                var response = await client.SendAsync(request);
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<PaginatedResult<InvoiceListItem>>(content);
+
+                // Assert
+                _httpTest.ShouldNotHaveMadeACall();
+
+                Assert.Collection(result.Items,
+                    invoice1 => Assert.Equal("Prod 19", invoice1.Product),
+                    invoice2 => Assert.Equal("Prod 2", invoice2.Product),
+                    invoice3 => Assert.Equal("Prod 20", invoice3.Product),
+                    invoice4 => Assert.Equal("Prod 21", invoice4.Product),
+                    invoice5 => Assert.Equal("Prod 22", invoice5.Product),
+                    invoice6 => Assert.Equal("Prod 23", invoice6.Product),
+                    invoice7 => Assert.Equal("Prod 24", invoice7.Product),
+                    invoice8 => Assert.Equal("Prod 25", invoice8.Product),
+                    invoice9 => Assert.Equal("Prod 26", invoice9.Product),
+                    invoice10 => Assert.Equal("Prod 27", invoice10.Product));
             }
         }
 

--- a/Billing.API/Billing.API.csproj
+++ b/Billing.API/Billing.API.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.2" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.2" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
     <PackageReference Include="Z.ExtensionMethods" Version="2.1.1" />
   </ItemGroup>

--- a/Billing.API/Controllers/InvoiceController.cs
+++ b/Billing.API/Controllers/InvoiceController.cs
@@ -23,14 +23,19 @@ namespace Billing.API.Controllers
         }
 
         [HttpGet("/accounts/{origin}/{clientId:int:min(0)}/invoices/")]
-        public async Task<IActionResult> GetInvoices([FromRoute] string origin, [FromRoute] int clientId, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+        public async Task<IActionResult> GetInvoices([FromRoute] string origin,
+            [FromRoute] int clientId,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortColumn = "AccountId",
+            [FromQuery] bool sortAsc = true)
         {
             _logger.LogDebug("Getting invoices for {0} client {1}", origin, clientId);
 
             if (!TryGetClientPrefix(origin, out var clientPrefix))
                 return BadRequest();
 
-            var response = await _invoiceService.GetInvoices(clientPrefix, clientId, page, pageSize);
+            var response = await _invoiceService.GetInvoices(clientPrefix, clientId, page, pageSize, sortColumn, sortAsc);
 
             return Ok(response);
         }

--- a/Billing.API/Services/Invoice/DummyInvoiceService.cs
+++ b/Billing.API/Services/Invoice/DummyInvoiceService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Billing.API.Models;
 
@@ -9,12 +10,12 @@ namespace Billing.API.Services.Invoice
 {
     public class DummyInvoiceService : IInvoiceService
     {
-        public async Task<PaginatedResult<InvoiceListItem>> GetInvoices(string clientPrefix, int clientId, int page, int pageSize)
+        public async Task<PaginatedResult<InvoiceListItem>> GetInvoices(string clientPrefix, int clientId, int page, int pageSize, string sortColumn, bool sortAsc)
         {
             if (clientId <= 0)
                 throw new ArgumentException();
 
-            var invoices = GetDummyInvoices(clientPrefix, clientId, page, pageSize);
+            var invoices = GetDummyInvoices(clientPrefix, clientId, page, pageSize, sortColumn, sortAsc);
 
             return await Task.FromResult(invoices);
         }
@@ -31,7 +32,7 @@ namespace Billing.API.Services.Invoice
             return await Task.FromResult("Successfull");
         }
 
-        private PaginatedResult<InvoiceListItem> GetDummyInvoices(string clientPrefix, int clientId, int page, int pageSize)
+        private PaginatedResult<InvoiceListItem> GetDummyInvoices(string clientPrefix, int clientId, int page, int pageSize, string sortColumn, bool sortAsc)
         {
             var invoices = Enumerable.Range(1, 50).Select(x => new InvoiceListItem(
                 $"Prod {x}",
@@ -44,12 +45,27 @@ namespace Billing.API.Services.Invoice
 
             var paginatedInvoices = invoices;
 
+            invoices = GetInvoicesSorted(invoices, sortColumn, sortAsc);
+
             if ((page > 0) && (pageSize > 0))
             {
                 paginatedInvoices = invoices.Skip((page - 1) * pageSize).Take(pageSize).ToList();
             }
 
             return new PaginatedResult<InvoiceListItem> { Items = paginatedInvoices, TotalItems = invoices.Count };
+        }
+
+        private List<InvoiceListItem> GetInvoicesSorted(List<InvoiceListItem> invoices, string sortColumn, bool sortAsc)
+        {
+            var property = typeof(InvoiceListItem).GetProperty(sortColumn, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance) ?? typeof(InvoiceListItem).GetProperty("AccountId");
+
+            if (property != null)
+            {
+                return sortAsc ? invoices.OrderBy(x => property.GetValue(x, null)).ToList()
+                    : invoices.OrderByDescending(x => property.GetValue(x, null)).ToList();
+            }
+
+            return invoices;
         }
     }
 }

--- a/Billing.API/Services/Invoice/IInvoiceService.cs
+++ b/Billing.API/Services/Invoice/IInvoiceService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Billing.API.Models;
 
@@ -6,7 +5,7 @@ namespace Billing.API.Services.Invoice
 {
     public interface IInvoiceService
     {
-        Task<PaginatedResult<InvoiceListItem>> GetInvoices(string clientPrefix, int clientId, int page, int pageSize);
+        Task<PaginatedResult<InvoiceListItem>> GetInvoices(string clientPrefix, int clientId, int page, int pageSize, string sortColumn, bool sortAsc);
 
         Task<byte[]> GetInvoiceFile(string clientPrefix, int clientId, int fileId);
 


### PR DESCRIPTION
# Background
Integrate sorting into the Invoices list. The user can sort by AccountId, Product, Date, Currency, and Amount.
Front-end task: https://github.com/MakingSense/Doppler/pull/7306

Default values:
Column: AccountId
Asc: true