### PR TITLE
Public PDF URL

### DIFF
--- a/Billing.API.Test/InvoiceApiTest.cs
+++ b/Billing.API.Test/InvoiceApiTest.cs
@@ -338,8 +338,7 @@ namespace Billing.API.Test
         }
 
         [Theory]
-        [InlineData("accounts/doppler/1/invoice/invoice_2020-01-01_123.pdf")] //Deprecated route
-        [InlineData("accounts/doppler/1/invoices/invoice_2020-01-01_123.pdf")]
+        [InlineData("accounts/doppler/1/invoices/invoice_2020-01-01_123.pdf?signature=792naTFnk0doxkAi3G4Dt2ITSQttLcf6OypamgKuV0")]
         public async Task GetInvoiceFile_ShouldReturnPdfFileContents(string path)
         {
             // Arrange
@@ -378,7 +377,7 @@ namespace Billing.API.Test
 
                 var client = appFactory.CreateClient();
 
-                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/invalid_origin/1/invoice/filename.ext");
+                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/invalid_origin/1/invoices/filename.ext?s=123456");
 
                 // Act
                 var response = await client.SendAsync(request);
@@ -403,7 +402,7 @@ namespace Billing.API.Test
 
                 var client = appFactory.CreateClient();
 
-                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/doppler/0/invoice/invoice_2020-01-01_123.pdf");
+                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/doppler/0/invoices/invoice_2020-01-01_123.pdf?s=123456");
 
                 // Act
                 var response = await client.SendAsync(request);
@@ -428,7 +427,7 @@ namespace Billing.API.Test
 
                 var client = appFactory.CreateClient();
 
-                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/doppler/1/invoice/whatever.ext");
+                var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/accounts/doppler/1/invoices/whatever.ext");
 
                 // Act
                 var response = await client.SendAsync(request);

--- a/Billing.API/DopplerSecurity/CryptoHelper.cs
+++ b/Billing.API/DopplerSecurity/CryptoHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Billing.API.Services.Invoice;
+using Microsoft.Extensions.Options;
+
+namespace Billing.API.DopplerSecurity
+{
+    public class CryptoHelper
+    {
+        private readonly string _signatureHashKey;
+
+        public CryptoHelper(IOptions<InvoiceProviderOptions> options)
+        {
+            _signatureHashKey = options.Value.SignatureHashKey;
+        }
+
+        public string GenerateInvoiceSign(string payload)
+        {
+            var key = $"{payload}{_signatureHashKey}";
+
+            using (var sha256 = SHA256.Create())
+            {
+                var bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(key));
+
+                return Convert.ToBase64String(bytes).ReplaceByEmpty("/", "+", "=");
+            }
+        }
+    }
+}

--- a/Billing.API/Models/InvoiceListItem.cs
+++ b/Billing.API/Models/InvoiceListItem.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Billing.API.Models
 {
@@ -9,9 +11,16 @@ namespace Billing.API.Models
         public DateTimeOffset Date { get; }
         public string Currency { get; }
         public double Amount { get; }
+
+        [JsonIgnore]
+        public int FileId { get; }
+
         public string Filename { get; }
 
-        public InvoiceListItem(string product, string accountId, DateTimeOffset date, string currency, double amount, string filename)
+        [JsonProperty(PropertyName = "_links")]
+        public List<Link> Links { get; } = new List<Link>();
+
+        public InvoiceListItem(string product, string accountId, DateTimeOffset date, string currency, double amount, string filename, int fileId)
         {
             Product = product.EqualsIgnoreCase("CD") ? "Doppler"
                 : product.EqualsIgnoreCase("CR") ? "Relay"
@@ -22,6 +31,7 @@ namespace Billing.API.Models
             Currency = currency;
             Amount = amount;
             Filename = filename;
+            FileId = fileId;
         }
     }
 }

--- a/Billing.API/Models/Link.cs
+++ b/Billing.API/Models/Link.cs
@@ -1,0 +1,9 @@
+namespace Billing.API.Models
+{
+    public class Link
+    {
+        public string Rel { get; set; }
+        public string Href { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/Billing.API/Services/Invoice/InvoiceProviderOptions.cs
+++ b/Billing.API/Services/Invoice/InvoiceProviderOptions.cs
@@ -3,10 +3,9 @@ namespace Billing.API.Services.Invoice
     public class InvoiceProviderOptions
     {
         public bool UseDummyData { get; set; }
-        public string Host { get; set; } = string.Empty;
-        public string Username { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
         public string Schema { get; set; } = string.Empty;
         public string DbConnectionString { get; set; } = string.Empty;
+        public string SignatureHashKey { get; set; } = string.Empty;
+        public string BaseUrl { get; set; } = string.Empty;
     }
 }

--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -19,7 +19,7 @@ namespace Billing.API.Services.Invoice
 
         public InvoiceService(ILogger<InvoiceService> logger, IOptions<InvoiceProviderOptions> options)
         {
-            _logger = logger;
+            _logger  = logger;
             _options = options;
         }
 
@@ -33,7 +33,8 @@ namespace Billing.API.Services.Invoice
                 dr.Field<DateTime>("SendDate").ToDateTimeOffSet(),
                 dr.Field<string>("DocCur"),
                 dr.Field<decimal>("DocTotal").ToDouble(),
-                $"invoice_{dr.Field<DateTime>("SendDate"):yyyy-MM-dd}_{dr.Field<int>("AbsEntry")}.{dr.Field<string>("FileExt")}"))
+                $"invoice_{dr.Field<DateTime>("SendDate"):yyyy-MM-dd}_{dr.Field<int>("AbsEntry")}.{dr.Field<string>("FileExt")}",
+                dr.Field<int>("AbsEntry")))
                 .AsQueryable();
 
             //TODO: When we can get the data from database we will try to move the pagination into the sql query

--- a/Billing.API/Startup.cs
+++ b/Billing.API/Startup.cs
@@ -1,3 +1,4 @@
+using Billing.API.DopplerSecurity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -19,6 +20,9 @@ namespace Billing.API
         {
             services.AddDopplerSecurity();
             services.AddInvoiceService();
+
+            services.AddTransient<CryptoHelper>();
+
             services.AddCors();
             // TODO: configure JSON to indent the results
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);

--- a/Billing.API/appsettings.int.json
+++ b/Billing.API/appsettings.int.json
@@ -8,7 +8,6 @@
   },
   "Invoice": {
     "UseDummyData": true,
-    "Schema": "TEST_MSARG",
     "SignatureHashKey": "nW98AXsLp8Tth7hG",
     "BaseUrl": "https://apisint.fromdoppler.net/billing-api"
   }

--- a/Billing.API/appsettings.json
+++ b/Billing.API/appsettings.json
@@ -10,6 +10,8 @@
   "PublicKeysFolder": "public-keys",
   "Invoice": {
     "DbConnectionString": "Server=172.25.16.86:30015;UserName=DOPPLER;Password={{ REPLACE PASSWORD HERE }};",
-    "Schema": "MSARGPROD"
+    "Schema": "MSARGPROD",
+    "SignatureHashKey": "nW98AXsLp8Tth7hG",
+    "BaseUrl": "https://apis.fromdoppler.com/billing-api"
   }
 }

--- a/Billing.API/appsettings.qa.json
+++ b/Billing.API/appsettings.qa.json
@@ -8,8 +8,7 @@
   },
   "Invoice": {
     "UseDummyData": true,
-    "Schema": "TEST_MSARG",
     "SignatureHashKey": "nW98AXsLp8Tth7hG",
-    "BaseUrl": "https://apisint.fromdoppler.net/billing-api"
+    "BaseUrl": "https://apisqa.fromdoppler.net/billing-api"
   }
 }


### PR DESCRIPTION
### Background

We need a public URL to allow the client to download the PDF files. In order to do so, the url must have a sign logic so it cannot be hacked

### Changes

- Added a public endpoint (no Authorization needed) to download the PDF file
- The URL has a hash that is calculated in the background with a key
- For the get invoices URL added the Link structure