### PR TITLE
feat(invoices): add creation date and due date in the in the invoices

### DIFF
--- a/Billing.API/Models/InvoiceListItem.cs
+++ b/Billing.API/Models/InvoiceListItem.cs
@@ -8,6 +8,9 @@ namespace Billing.API.Models
     {
         public string Product { get; }
         public string AccountId { get; }
+        public DateTimeOffset CreationDate { get; }
+        public DateTimeOffset DueDate { get; }
+        [Obsolete("Use CreationDate or DueDate in place of this.")]
         public DateTimeOffset Date { get; }
         public string Currency { get; }
         public double Amount { get; }
@@ -20,13 +23,15 @@ namespace Billing.API.Models
         [JsonProperty(PropertyName = "_links")]
         public List<Link> Links { get; } = new List<Link>();
 
-        public InvoiceListItem(string product, string accountId, DateTimeOffset date, string currency, double amount, string filename, int fileId)
+        public InvoiceListItem(string product, string accountId, DateTimeOffset creationDate, DateTimeOffset dueDate, DateTimeOffset date, string currency, double amount, string filename, int fileId)
         {
             Product = product.EqualsIgnoreCase("CD") ? "Doppler"
                 : product.EqualsIgnoreCase("CR") ? "Relay"
                 : product.EqualsIgnoreCase("CM") ? "Client Manager"
                 : product;
             AccountId = accountId;
+            CreationDate = creationDate;
+            DueDate = dueDate;
             Date = date;
             Currency = currency;
             Amount = amount;

--- a/Billing.API/Services/Invoice/DummyInvoiceService.cs
+++ b/Billing.API/Services/Invoice/DummyInvoiceService.cs
@@ -48,6 +48,8 @@ namespace Billing.API.Services.Invoice
             var invoices = Enumerable.Range(1, 50).Select(x => new InvoiceListItem(
                 $"Prod {x}",
                 $"{clientPrefix}{clientId:0000000000000}",
+                new DateTimeOffset(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day, 0, 0, 0, TimeSpan.Zero).AddDays(x),
+                new DateTimeOffset(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day, 0, 0, 0, TimeSpan.Zero).AddDays(x + 15),
                 DateTime.Today.AddDays(x),
                 "ARS",
                 100,

--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -30,6 +30,8 @@ namespace Billing.API.Services.Invoice
             var invoices = dt.Select().Select(dr => new InvoiceListItem(
                 clientPrefix,
                 clientId.ToString(),
+                dr.Field<DateTime>("CreateDate").ToDateTimeOffSet(),
+                dr.Field<DateTime>("DocDueDate").ToDateTimeOffSet(),
                 dr.Field<DateTime>("SendDate").ToDateTimeOffSet(),
                 dr.Field<string>("DocCur"),
                 dr.Field<decimal>("DocTotal").ToDouble(),
@@ -119,6 +121,8 @@ namespace Billing.API.Services.Invoice
                 query += $"     cast(OEM.\"DocEntry\" AS NVARCHAR) AS \"DocEntry\" ,";
                 query += $"     OI.\"DocTotal\" ,";
                 query += $"     OI.\"PaidToDate\" ,";
+                query += "      OI.\"CreateDate\" ,";
+                query += "      OI.\"DocDueDate\" ,";
                 query += $"     cast(OI.\"DocCur\" AS NVARCHAR)   AS \"DocCur\" ,";
                 query += $"     cast(AT1.\"trgtPath\" AS NVARCHAR) AS \"trgtPath\" ,";
                 query += $"     cast(AT1.\"FileName\" AS NVARCHAR) AS \"FileName\" ,";


### PR DESCRIPTION
Added the ```creation date``` and ```due date``` properties in the invoice and return these properties in the endpoint to get the invoices:

![image](https://user-images.githubusercontent.com/70591946/96011029-d629ce00-0e18-11eb-91b0-593c6a970c1d.png)


Task: [DAT-156](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-156)

Tested locally using the Dummy service and also using the service to get the information from the Hana database.
