### PR TITLE
Split authentication and authorization validating signed path requests

### DIFF
--- a/Billing.API/Controllers/InvoiceController.cs
+++ b/Billing.API/Controllers/InvoiceController.cs
@@ -61,7 +61,7 @@ namespace Billing.API.Controllers
         }
 
         [HttpGet]
-        [Authorize("TokenSignature")]
+        [Authorize(DopplerSecurityDefaults.DEFAULT_OR_SIGNED_PATHS_POLICY)]
         [Route("/accounts/{origin}/{clientId:int:min(1)}/invoices/{filename}")]
         public async Task<IActionResult> GetInvoiceFile([FromRoute] string origin, [FromRoute] int clientId, [FromRoute] string filename, [FromQuery(Name = "_s")] string signature)
         {

--- a/Billing.API/DopplerSecurity/ConfigureDopplerSecurityOptions.cs
+++ b/Billing.API/DopplerSecurity/ConfigureDopplerSecurityOptions.cs
@@ -41,7 +41,9 @@ namespace Billing.API.DopplerSecurity
 
         public void Configure(DopplerSecurityOptions options)
         {
-            var path = _configuration.GetValue("PublicKeysFolder", "public-keys");
+            var path = _configuration.GetValue(
+                DopplerSecurityDefaults.PUBLIC_KEYS_FOLDER_CONFIG_KEY,
+                DopplerSecurityDefaults.PUBLIC_KEYS_FOLDER_DEFAULT_CONFIG_VALUE);
             var files = _fileProvider.GetDirectoryContents(path).Where(x => !x.IsDirectory);
             var publicKeys = files
                 .Select(ReadToEnd)

--- a/Billing.API/DopplerSecurity/DopplerAuthorizationRequirement.cs
+++ b/Billing.API/DopplerSecurity/DopplerAuthorizationRequirement.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Billing.API.DopplerSecurity
+{
+    public class DopplerAuthorizationRequirement : IAuthorizationRequirement
+    {
+        public bool AllowSuperUser { get; set; }
+        public bool AllowOwnResource { get; set; }
+        public bool AllowSignedPaths { get; set; }
+    }
+}

--- a/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
@@ -6,5 +6,8 @@ namespace Billing.API.DopplerSecurity
         public const string SIGNED_PATH_SCHEME = "SignedPath";
         public const string SIGNED_PATH_CLAIM_TYPE = "SignedPath";
         public const string SIGNED_PATH_QUERY_STRING_PARAMETER_NAME = "_s";
+        public const string PUBLIC_KEYS_FOLDER_CONFIG_KEY = "PublicKeysFolder";
+        public const string PUBLIC_KEYS_FOLDER_DEFAULT_CONFIG_VALUE = "public-keys";
+        public const string SUPERUSER_JWT_KEY = "isSU";
     }
 }

--- a/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
@@ -3,5 +3,8 @@ namespace Billing.API.DopplerSecurity
     public static class DopplerSecurityDefaults
     {
         public const string DEFAULT_OR_SIGNED_PATHS_POLICY = "DefaultOrSignedPathsPolicy";
+        public const string SIGNED_PATH_SCHEME = "SignedPath";
+        public const string SIGNED_PATH_CLAIM_TYPE = "SignedPath";
+        public const string SIGNED_PATH_QUERY_STRING_PARAMETER_NAME = "_s";
     }
 }

--- a/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityDefaults.cs
@@ -1,0 +1,7 @@
+namespace Billing.API.DopplerSecurity
+{
+    public static class DopplerSecurityDefaults
+    {
+        public const string DEFAULT_OR_SIGNED_PATHS_POLICY = "DefaultOrSignedPathsPolicy";
+    }
+}

--- a/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddDopplerSecurity(this IServiceCollection services)
         {
-            services.AddSingleton<IAuthorizationHandler, IsOwnResourceHandler<IsSuperUserOrOwnResourceRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsSuperUserHandler<IsSuperUserOrOwnResourceRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler<IsSuperUserOrOwnResourceRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsSuperUserAuthorizationHandler<IsSuperUserOrOwnResourceRequirement>>();
 
-            services.AddSingleton<IAuthorizationHandler, IsOwnResourceHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsSuperUserHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsValidSignatureHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsSuperUserAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsSignedPathAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
 
             services.ConfigureOptions<ConfigureDopplerSecurityOptions>();
 

--- a/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
@@ -31,13 +31,15 @@ namespace Microsoft.Extensions.DependencyInjection
                         .Build();
 
                     o.AddPolicy(DopplerSecurityDefaults.DEFAULT_OR_SIGNED_PATHS_POLICY, new AuthorizationPolicyBuilder()
-                        .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme) //TODO: Check which scheme to use
+                        .AddAuthenticationSchemes(DopplerSecurityDefaults.SIGNED_PATH_SCHEME)
+                        .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
                         .AddRequirements(new DopplerAuthorizationRequirement
                         {
                             AllowSuperUser = true,
                             AllowOwnResource = true,
                             AllowSignedPaths = true
                         })
+                        .RequireAuthenticatedUser()
                         .Build());
                 });
 
@@ -55,7 +57,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     };
                 });
 
-            services.AddAuthentication().AddJwtBearer();
+            services.AddAuthentication()
+                .AddJwtBearer()
+                .AddScheme<SignedPathAuthenticationSchemeOptions, SignedPathAuthenticationHandler>(DopplerSecurityDefaults.SIGNED_PATH_SCHEME, _ => {});
 
             services.AddAuthorization();
 

--- a/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
@@ -12,12 +12,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddDopplerSecurity(this IServiceCollection services)
         {
-            services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler<IsSuperUserOrOwnResourceRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsSuperUserAuthorizationHandler<IsSuperUserOrOwnResourceRequirement>>();
-
-            services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsSuperUserAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
-            services.AddSingleton<IAuthorizationHandler, IsSignedPathAuthorizationHandler<IsSuperUserOrOwnResourceOrValidSignatureRequirement>>();
+            services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, IsSuperUserAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, IsSignedPathAuthorizationHandler>();
 
             services.ConfigureOptions<ConfigureDopplerSecurityOptions>();
 
@@ -27,13 +24,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     o.DefaultPolicy = new AuthorizationPolicyBuilder()
                         .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
-                        .AddRequirements(new IsSuperUserOrOwnResourceRequirement())
+                        .AddRequirements(new DopplerAuthorizationRequirement
+                        {
+                            AllowSuperUser = true,
+                            AllowOwnResource = true
+                        })
                         .RequireAuthenticatedUser()
                         .Build();
 
                     o.AddPolicy(TOKEN_SIGNATURE_POLICY, new AuthorizationPolicyBuilder()
                         .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme) //TODO: Check which scheme to use
-                        .AddRequirements(new IsSuperUserOrOwnResourceOrValidSignatureRequirement())
+                        .AddRequirements(new DopplerAuthorizationRequirement
+                        {
+                            AllowSuperUser = true,
+                            AllowOwnResource = true,
+                            AllowSignedPaths = true
+                        })
                         .Build());
                 });
 

--- a/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
+++ b/Billing.API/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class DopplerSecurityServiceCollectionExtensions
     {
-        private const string TOKEN_SIGNATURE_POLICY = "TokenSignature";
-
         public static IServiceCollection AddDopplerSecurity(this IServiceCollection services)
         {
             services.AddSingleton<IAuthorizationHandler, IsOwnResourceAuthorizationHandler>();
@@ -32,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         .RequireAuthenticatedUser()
                         .Build();
 
-                    o.AddPolicy(TOKEN_SIGNATURE_POLICY, new AuthorizationPolicyBuilder()
+                    o.AddPolicy(DopplerSecurityDefaults.DEFAULT_OR_SIGNED_PATHS_POLICY, new AuthorizationPolicyBuilder()
                         .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme) //TODO: Check which scheme to use
                         .AddRequirements(new DopplerAuthorizationRequirement
                         {

--- a/Billing.API/DopplerSecurity/IsOwnResourceAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsOwnResourceAuthorizationHandler.cs
@@ -6,19 +6,18 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsOwnResourceAuthorizationHandler<T> : AuthorizationHandler<T>
-        where T: IAuthorizationRequirement
+    public class IsOwnResourceAuthorizationHandler : AuthorizationHandler<DopplerAuthorizationRequirement>
     {
-        private readonly ILogger<IsOwnResourceAuthorizationHandler<T>> _logger;
+        private readonly ILogger<IsOwnResourceAuthorizationHandler> _logger;
 
-        public IsOwnResourceAuthorizationHandler(ILogger<IsOwnResourceAuthorizationHandler<T>> logger)
+        public IsOwnResourceAuthorizationHandler(ILogger<IsOwnResourceAuthorizationHandler> logger)
         {
             _logger = logger;
         }
 
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, T requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, DopplerAuthorizationRequirement requirement)
         {
-            if (IsOwnResource(context))
+            if (requirement.AllowOwnResource && IsOwnResource(context))
             {
                 context.Succeed(requirement);
             }

--- a/Billing.API/DopplerSecurity/IsOwnResourceAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsOwnResourceAuthorizationHandler.cs
@@ -6,12 +6,12 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsOwnResourceHandler<T> : AuthorizationHandler<T>
+    public class IsOwnResourceAuthorizationHandler<T> : AuthorizationHandler<T>
         where T: IAuthorizationRequirement
     {
-        private readonly ILogger<IsOwnResourceHandler<T>> _logger;
+        private readonly ILogger<IsOwnResourceAuthorizationHandler<T>> _logger;
 
-        public IsOwnResourceHandler(ILogger<IsOwnResourceHandler<T>> logger)
+        public IsOwnResourceAuthorizationHandler(ILogger<IsOwnResourceAuthorizationHandler<T>> logger)
         {
             _logger = logger;
         }

--- a/Billing.API/DopplerSecurity/IsSignedPathAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsSignedPathAuthorizationHandler.cs
@@ -5,13 +5,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsValidSignatureHandler<T> : AuthorizationHandler<T>
+    public class IsSignedPathAuthorizationHandler<T> : AuthorizationHandler<T>
         where T : IAuthorizationRequirement
     {
-        private readonly ILogger<IsValidSignatureHandler<T>> _logger;
+        private readonly ILogger<IsSignedPathAuthorizationHandler<T>> _logger;
         private readonly CryptoHelper _cryptoHelper;
 
-        public IsValidSignatureHandler(ILogger<IsValidSignatureHandler<T>> logger, CryptoHelper cryptoHelper)
+        public IsSignedPathAuthorizationHandler(ILogger<IsSignedPathAuthorizationHandler<T>> logger, CryptoHelper cryptoHelper)
         {
             _logger = logger;
             _cryptoHelper = cryptoHelper;

--- a/Billing.API/DopplerSecurity/IsSignedPathAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsSignedPathAuthorizationHandler.cs
@@ -5,21 +5,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsSignedPathAuthorizationHandler<T> : AuthorizationHandler<T>
-        where T : IAuthorizationRequirement
+    public class IsSignedPathAuthorizationHandler : AuthorizationHandler<DopplerAuthorizationRequirement>
     {
-        private readonly ILogger<IsSignedPathAuthorizationHandler<T>> _logger;
+        private readonly ILogger<IsSignedPathAuthorizationHandler> _logger;
         private readonly CryptoHelper _cryptoHelper;
 
-        public IsSignedPathAuthorizationHandler(ILogger<IsSignedPathAuthorizationHandler<T>> logger, CryptoHelper cryptoHelper)
+        public IsSignedPathAuthorizationHandler(ILogger<IsSignedPathAuthorizationHandler> logger, CryptoHelper cryptoHelper)
         {
             _logger = logger;
             _cryptoHelper = cryptoHelper;
         }
 
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, T requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, DopplerAuthorizationRequirement requirement)
         {
-            if (IsValidSignature(context))
+            if (requirement.AllowSignedPaths && IsValidSignature(context))
             {
                 context.Succeed(requirement);
             }

--- a/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
@@ -29,13 +29,13 @@ namespace Billing.API.DopplerSecurity
 
         private bool IsSuperUser(AuthorizationHandlerContext context)
         {
-            if (!context.User.HasClaim(c => c.Type.Equals("isSU")))
+            if (!context.User.HasClaim(c => c.Type.Equals(DopplerSecurityDefaults.SUPERUSER_JWT_KEY)))
             {
                 _logger.LogDebug("The token hasn't super user permissions.");
                 return false;
             }
 
-            var isSuperUser = bool.Parse(context.User.FindFirst(c => c.Type.Equals("isSU")).Value);
+            var isSuperUser = bool.Parse(context.User.FindFirst(c => c.Type.Equals(DopplerSecurityDefaults.SUPERUSER_JWT_KEY)).Value);
             if (isSuperUser)
             {
                 return true;

--- a/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
@@ -8,19 +8,18 @@ using System.Threading.Tasks;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsSuperUserAuthorizationHandler<T> : AuthorizationHandler<T>
-        where T: IAuthorizationRequirement
+    public class IsSuperUserAuthorizationHandler : AuthorizationHandler<DopplerAuthorizationRequirement>
     {
-        private readonly ILogger<IsSuperUserAuthorizationHandler<T>> _logger;
+        private readonly ILogger<IsSuperUserAuthorizationHandler> _logger;
 
-        public IsSuperUserAuthorizationHandler(ILogger<IsSuperUserAuthorizationHandler<T>> logger)
+        public IsSuperUserAuthorizationHandler(ILogger<IsSuperUserAuthorizationHandler> logger)
         {
             _logger = logger;
         }
 
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, T requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, DopplerAuthorizationRequirement requirement)
         {
-            if (IsSuperUser(context))
+            if (requirement.AllowSuperUser && IsSuperUser(context))
             {
                 context.Succeed(requirement);
             }

--- a/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
+++ b/Billing.API/DopplerSecurity/IsSuperUserAuthorizationHandler.cs
@@ -8,12 +8,12 @@ using System.Threading.Tasks;
 
 namespace Billing.API.DopplerSecurity
 {
-    public class IsSuperUserHandler<T> : AuthorizationHandler<T>
+    public class IsSuperUserAuthorizationHandler<T> : AuthorizationHandler<T>
         where T: IAuthorizationRequirement
     {
-        private readonly ILogger<IsSuperUserHandler<T>> _logger;
+        private readonly ILogger<IsSuperUserAuthorizationHandler<T>> _logger;
 
-        public IsSuperUserHandler(ILogger<IsSuperUserHandler<T>> logger)
+        public IsSuperUserAuthorizationHandler(ILogger<IsSuperUserAuthorizationHandler<T>> logger)
         {
             _logger = logger;
         }

--- a/Billing.API/DopplerSecurity/IsSuperUserOrOwnResourceOrValidSignatureRequirement.cs
+++ b/Billing.API/DopplerSecurity/IsSuperUserOrOwnResourceOrValidSignatureRequirement.cs
@@ -1,8 +1,0 @@
-using Microsoft.AspNetCore.Authorization;
-
-namespace Billing.API.DopplerSecurity
-{
-    public class IsSuperUserOrOwnResourceOrValidSignatureRequirement : IAuthorizationRequirement
-    {
-    }
-}

--- a/Billing.API/DopplerSecurity/IsSuperUserOrOwnResourceRequirement.cs
+++ b/Billing.API/DopplerSecurity/IsSuperUserOrOwnResourceRequirement.cs
@@ -1,8 +1,0 @@
-using Microsoft.AspNetCore.Authorization;
-
-namespace Billing.API.DopplerSecurity
-{
-    public class IsSuperUserOrOwnResourceRequirement : IAuthorizationRequirement
-    {
-    }
-}

--- a/Billing.API/DopplerSecurity/SignedPathAuthenticationHandler.cs
+++ b/Billing.API/DopplerSecurity/SignedPathAuthenticationHandler.cs
@@ -1,0 +1,60 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using System.Text.Encodings.Web;
+
+namespace Billing.API.DopplerSecurity
+{
+    public class SignedPathAuthenticationHandler : AuthenticationHandler<SignedPathAuthenticationSchemeOptions>
+    {
+        private readonly ILogger<SignedPathAuthenticationHandler> _logger;
+        private readonly CryptoHelper _cryptoHelper;
+
+        public SignedPathAuthenticationHandler(
+            IOptionsMonitor<SignedPathAuthenticationSchemeOptions> options,
+            ILoggerFactory loggerFactory,
+            UrlEncoder encoder,
+            ISystemClock clock,
+            CryptoHelper cryptoHelper,
+            ILogger<SignedPathAuthenticationHandler> logger)
+            : base(options, loggerFactory, encoder, clock)
+        {
+            _logger = logger;
+            _cryptoHelper = cryptoHelper;
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Query.TryGetValue(Options.QueryStringParameterName, out var signature))
+            {
+                _logger.LogDebug("Cannot get the Signature from the query string.");
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            if (_cryptoHelper.GenerateSignature(Request.Path) != signature)
+            {
+                _logger.LogWarning("Wrong signature for requested path.");
+                // TODO: Consider return Fail in place of NoResult when the
+                // signature is wrong
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var identity = new ClaimsIdentity(
+                authenticationType: DopplerSecurityDefaults.SIGNED_PATH_SCHEME,
+                nameType: ClaimsIdentity.DefaultNameClaimType,
+                roleType: ClaimsIdentity.DefaultRoleClaimType);
+
+            identity.BootstrapContext = signature;
+            identity.AddClaim(new Claim(DopplerSecurityDefaults.SIGNED_PATH_CLAIM_TYPE, Request.Path));
+            var principal =  new ClaimsPrincipal(identity);
+
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(
+                    principal,
+                    DopplerSecurityDefaults.SIGNED_PATH_SCHEME
+            )));
+        }
+    }
+}

--- a/Billing.API/DopplerSecurity/SignedPathAuthenticationSchemeOptions.cs
+++ b/Billing.API/DopplerSecurity/SignedPathAuthenticationSchemeOptions.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Billing.API.DopplerSecurity
+{
+    public class SignedPathAuthenticationSchemeOptions : AuthenticationSchemeOptions
+    {
+        public string QueryStringParameterName { get; set; } = DopplerSecurityDefaults.SIGNED_PATH_QUERY_STRING_PARAMETER_NAME;
+    }
+}


### PR DESCRIPTION
Hi team, 

The idea is simplifying our logic for authentication and authorization.

The first commit is a refactor to make the security requirement specific to our scenario and simplify the _OR logic_. 

The last one is to split signed path validation in authentication and authorization. The authorization does not depend on the signature, only on a list of allowed paths. The authentication is tied to a specific authentication schema.

Could you kindly review it?

### Pending

- [x] Test it manually
- [x] Review the names, maybe _signed-path_ is better than _token signature_
- [x]  fix some format issues like [this one](https://github.com/FromDoppler/doppler-billing-api/pull/71#discussion_r506357712-permalink)
