### PR TITLE
feat(invoices): return the paid to date and balance in the invoices endpoint

### DIFF
--- a/Billing.API/Models/InvoiceListItem.cs
+++ b/Billing.API/Models/InvoiceListItem.cs
@@ -14,6 +14,8 @@ namespace Billing.API.Models
         public DateTimeOffset Date { get; }
         public string Currency { get; }
         public double Amount { get; }
+        public double PaidToDate { get; }
+        public double Balance { get { return Amount - PaidToDate; } }
 
         [JsonIgnore]
         public int FileId { get; }
@@ -23,7 +25,7 @@ namespace Billing.API.Models
         [JsonProperty(PropertyName = "_links")]
         public List<Link> Links { get; } = new List<Link>();
 
-        public InvoiceListItem(string product, string accountId, DateTimeOffset creationDate, DateTimeOffset dueDate, DateTimeOffset date, string currency, double amount, string filename, int fileId)
+        public InvoiceListItem(string product, string accountId, DateTimeOffset creationDate, DateTimeOffset dueDate, DateTimeOffset date, string currency, double amount, double paidToDate, string filename, int fileId)
         {
             Product = product.EqualsIgnoreCase("CD") ? "Doppler"
                 : product.EqualsIgnoreCase("CR") ? "Relay"
@@ -35,6 +37,7 @@ namespace Billing.API.Models
             Date = date;
             Currency = currency;
             Amount = amount;
+            PaidToDate = paidToDate;
             Filename = filename;
             FileId = fileId;
         }

--- a/Billing.API/Services/Invoice/DummyInvoiceService.cs
+++ b/Billing.API/Services/Invoice/DummyInvoiceService.cs
@@ -53,6 +53,7 @@ namespace Billing.API.Services.Invoice
                 DateTime.Today.AddDays(x),
                 "ARS",
                 100,
+                50,
                 $"invoice_{DateTime.Today.AddDays(x):yyyy-MM-dd}_{x}.pdf",
                 x)
             ).AsQueryable();

--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -35,6 +35,7 @@ namespace Billing.API.Services.Invoice
                 dr.Field<DateTime>("SendDate").ToDateTimeOffSet(),
                 dr.Field<string>("DocCur"),
                 dr.Field<decimal>("DocTotal").ToDouble(),
+                dr.Field<decimal>("PaidToDate").ToDouble(),
                 $"invoice_{dr.Field<DateTime>("SendDate"):yyyy-MM-dd}_{dr.Field<int>("AbsEntry")}.{dr.Field<string>("FileExt")}",
                 dr.Field<int>("AbsEntry")))
                 .AsQueryable();
@@ -120,7 +121,7 @@ namespace Billing.API.Services.Invoice
                 query += $"     OEM.\"SendTime\" ,";
                 query += $"     cast(OEM.\"DocEntry\" AS NVARCHAR) AS \"DocEntry\" ,";
                 query += $"     OI.\"DocTotal\" ,";
-                query += $"     OI.\"PaidToDate\" ,";
+                query += "      OI.\"PaidToDate\" ,";
                 query += "      OI.\"CreateDate\" ,";
                 query += "      OI.\"DocDueDate\" ,";
                 query += $"     cast(OI.\"DocCur\" AS NVARCHAR)   AS \"DocCur\" ,";


### PR DESCRIPTION
Returns the PaidToDate and Balance properties in the invoices endpoint:

![image](https://user-images.githubusercontent.com/70591946/96289195-fabdab80-0fba-11eb-8c18-cb81ef7cbeeb.png)

**Changes:**

- Added the PaidToDate and Balance properties in the InvoiceListItem object and return these in the invoices endpoint.

- Added an unit test to validate the balance is calculated correctly  .

**Task:** [DAT-41](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-41)