### PR TITLE
Signature key

### DIFF
--- a/Billing.API.Test/Billing.API.Test.csproj
+++ b/Billing.API.Test/Billing.API.Test.csproj
@@ -5,9 +5,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <AssemblyVersion>2020.10.16.13</AssemblyVersion>
+    <AssemblyVersion>2020.10.23.0</AssemblyVersion>
 
-    <FileVersion>2020.10.16.13</FileVersion>
+    <FileVersion>2020.10.23.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Billing.API.Test/InvoiceApiTest.cs
+++ b/Billing.API.Test/InvoiceApiTest.cs
@@ -346,7 +346,7 @@ namespace Billing.API.Test
         }
 
         [Theory]
-        [InlineData("accounts/doppler/1/invoices/invoice_2020-01-01_123.pdf?_s=q9Vb7OMljCgaNKd6aJbcQgxH7L6rKxy7eRfK30qDSyw")]
+        [InlineData("accounts/doppler/1/invoices/invoice_2020-01-01_123.pdf?_s=sOvP2buZIW8IFDAXMIe8BROG9GoB7zLPCzAv3OzVs")]
         public async Task GetInvoiceFile_WithNoTokenAndValidSignature_ShouldReturnPdfFileContents(string path)
         {
             // Arrange

--- a/Billing.API/Billing.API.csproj
+++ b/Billing.API/Billing.API.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyVersion>2020.10.16.12</AssemblyVersion>
-    <FileVersion>2020.10.16.12</FileVersion>
+    <AssemblyVersion>2020.10.23.0</AssemblyVersion>
+    <FileVersion>2020.10.23.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Billing.API/appsettings.Development.json
+++ b/Billing.API/appsettings.Development.json
@@ -9,7 +9,6 @@
   "Invoice": {
     "UseDummyData": true,
     "Schema": "TEST_MSARG",
-    "SignatureHashKey": "nW98AXsLp8Tth7hG",
     "BaseUrl": "https://apisint.fromdoppler.net/billing-api"
   }
 }

--- a/Billing.API/appsettings.int.json
+++ b/Billing.API/appsettings.int.json
@@ -8,7 +8,6 @@
   },
   "Invoice": {
     "UseDummyData": true,
-    "SignatureHashKey": "nW98AXsLp8Tth7hG",
     "BaseUrl": "https://apisint.fromdoppler.net/billing-api"
   }
 }

--- a/Billing.API/appsettings.json
+++ b/Billing.API/appsettings.json
@@ -11,7 +11,7 @@
   "Invoice": {
     "DbConnectionString": "Server=172.25.16.86:30015;UserName=DOPPLER;Password={{ REPLACE PASSWORD HERE }};",
     "Schema": "MSARGPROD",
-    "SignatureHashKey": "nW98AXsLp8Tth7hG",
+    "SignatureHashKey": "{{ REPLACE KEY HERE }}",
     "BaseUrl": "https://apis.fromdoppler.com/billing-api"
   }
 }

--- a/Billing.API/appsettings.qa.json
+++ b/Billing.API/appsettings.qa.json
@@ -8,7 +8,6 @@
   },
   "Invoice": {
     "UseDummyData": true,
-    "SignatureHashKey": "nW98AXsLp8Tth7hG",
     "BaseUrl": "https://apisqa.fromdoppler.net/billing-api"
   }
 }


### PR DESCRIPTION
### Background 

There is a need to remove the key that should not be public for generating and validating the signature from invoice URLs.

### Changes done

- Signature key is hidden in prod json
- Used different keys for dev and prod
- Used a larger key (256 chars) to make the encryption more secure 