### PR TITLE
chore(build): generate coverage report on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,5 @@ healthchecksdb
 .DS_Store
 docs/demo-cd-branches/dist
 wwwroot_extras/version.txt
+
+/Billing.API.Test/coverage.json

--- a/Billing.API.Test/Billing.API.Test.csproj
+++ b/Billing.API.Test/Billing.API.Test.csproj
@@ -13,6 +13,10 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN dotnet build -c Release
 
 FROM build AS test
-RUN dotnet test
+RUN dotnet test /p:CollectCoverage=true
 
 FROM build AS publish
 RUN dotnet publish "Billing.API/Billing.API.csproj" -c Release -o /app/publish


### PR DESCRIPTION
The objective is to start to have metrics on the test coverage of the application code, for this the
**coverlet.msbuild** tool was added to the api test project.
A parameter was added in the execution of the tests in the continuous integration, screenshots below:

![image](https://user-images.githubusercontent.com/3428723/96926808-74a6d680-148c-11eb-86ea-76bf62b91725.png)
![image](https://user-images.githubusercontent.com/3428723/96926892-943dff00-148c-11eb-9de7-c85db212042d.png)

It is worth mentioning that locally it can be executed locally with the same command that was added in the CI: 
**dotnet test /p:CollectCoverage=true**

