### PR TITLE
feat(invoices) remove duplicate invoices

### DIFF
--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -177,7 +177,7 @@ namespace Billing.API.Services.Invoice
             query += $"        WHERE T0.\"ObjType\" = '{queryData.ObjType}' AND ";
             query += $"              (T0.\"CardCode\" = '{clientPrefix}{clientId:0000000000000}' OR T0.\"CardCode\" LIKE '{clientPrefix}{clientId:00000000000}.%') ";
             query += "         GROUP BY T0.\"DocEntry\" ) x ON x.\"DocEntry\" = INV.\"DocEntry\" ";
-            query += $" INNER JOIN {schema}.ATC1 AT1 ON x.\"AtcEntry\" = AT1.\"AbsEntry\" ";
+            query += $" INNER JOIN {schema}.ATC1 AT1 ON x.\"AtcEntry\" = AT1.\"AbsEntry\" AND AT1.\"Line\" = 1 ";
             query += $" INNER JOIN {schema}.oeml OEM ON OEM.\"AbsEntry\" = x.\"AbsEntry\" ";
             query += $" WHERE INV.\"ObjType\" = '{queryData.ObjType}' AND ";
             query += $"       (INV.\"CardCode\" = '{clientPrefix}{clientId:0000000000000}' OR INV.\"CardCode\" LIKE '{clientPrefix}{clientId:00000000000}.%')";


### PR DESCRIPTION
### Background

For some clients the service was returning duplicate rows in Admin.

### Changes Done

We realized the problem was due to the Line field. For some clients, there are more than one line, so we did some other queries and detected that the 1 is the one that brings the invoice. There are  8 records that have Line 2 and none of them match with an invoice