### PR TITLE
feat: Return the "DocNum" of the invoice when the calculated "DocumentNumber" is null

### DIFF
--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -202,7 +202,7 @@ namespace Billing.API.Services.Invoice
             query += "     OEM.\"SendTime\" ,";
             query += "     cast(OEM.\"DocEntry\" AS NVARCHAR) AS \"DocEntry\" ,";
             query += $"    '{documentType}' AS \"DocumentType\", ";
-            query += "     INV.\"Letter\" || '-' || (Right(INV.\"PTICode\", 4) || '-' || Right('00000000' || COALESCE(INV.\"FolNumFrom\", '0'), 8))  AS \"DocumentNumber\", ";
+            query += "     IFNULL(INV.\"Letter\" || '-' || (Right(INV.\"PTICode\", 4) || '-' || Right('00000000' || COALESCE(INV.\"FolNumFrom\", '0'), 8)), CAST(INV.\"DocNum\" AS VARCHAR(10))) AS \"DocumentNumber\", ";
             query += $"    INV.\"DocTotal\" * {queryData.AmountFactor} AS \"DocTotal\" ,";
             query += $"    INV.\"PaidToDate\" * {queryData.AmountFactor} AS \"PaidToDate\" ,"; ;
             query += "      INV.\"CreateDate\" ,";


### PR DESCRIPTION
Returns the **"DocNum"** of the invoice when the calculated "DocumentNumber" is null.

**Calculated DocumentNumber:** ```INV.\"Letter\" || '-' || (Right(INV.\"PTICode\", 4) || '-' || Right('00000000' || COALESCE(INV.\"FolNumFrom\", '0'), 8))  AS \"DocumentNumber\"```

**Before:**

![image](https://user-images.githubusercontent.com/70591946/101939115-4cea0a00-3bc3-11eb-9105-9eca432fd5a8.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/101939150-596e6280-3bc3-11eb-8822-675f73fdf375.png)

**Task:** [DAT-227](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-227)
