### PR TITLE
chore(dates): format returning dates as `yyyy-MM-dd`

### DIFF
--- a/Billing.API/Models/InvoiceListItem.cs
+++ b/Billing.API/Models/InvoiceListItem.cs
@@ -10,14 +10,17 @@ namespace Billing.API.Models
         public string DocumentNumber { get; }
         public string Product { get; }
         public string AccountId { get; }
+        [JsonConverter(typeof(IsoDateConverter))]
         public DateTimeOffset CreationDate { get; }
+        [JsonConverter(typeof(IsoDateConverter))]
         public DateTimeOffset DueDate { get; }
         [Obsolete("Use CreationDate or DueDate in place of this.")]
+        [JsonConverter(typeof(IsoDateConverter))]
         public DateTimeOffset Date { get; }
         public string Currency { get; }
         public double Amount { get; }
         public double PaidToDate { get; }
-        public double Balance { get { return Amount - PaidToDate; } }
+        public double Balance => Amount - PaidToDate;
 
         [JsonIgnore]
         public int FileId { get; }

--- a/Billing.API/Models/IsoDateConverter.cs
+++ b/Billing.API/Models/IsoDateConverter.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json.Converters;
+
+namespace Billing.API.Models
+{
+    public class IsoDateConverter  : IsoDateTimeConverter
+    {
+        public IsoDateConverter()
+        {
+            base.DateTimeFormat = "yyyy-MM-dd";
+        }
+    }
+}


### PR DESCRIPTION
### Background

Since the datetimes are incorrectly displayed in Doppler and the time part is not necessary for invoices dates, we added the logic to strip time when serializing invoices.