### PR TITLE
fix: [DAT-515] Fix SQL consults with many delays

### DIFF
--- a/Billing.API/Controllers/InvoiceController.cs
+++ b/Billing.API/Controllers/InvoiceController.cs
@@ -101,6 +101,7 @@ namespace Billing.API.Controllers
         }
 
         [HttpGet]
+        [Authorize]
         [Route("/testSap")]
         public async Task<IActionResult> TestSapConnection()
         {
@@ -110,6 +111,7 @@ namespace Billing.API.Controllers
         }
 
         [HttpGet]
+        [Authorize]
         [Route("/testSapUs")]
         public async Task<IActionResult> TestSapUsConnection()
         {

--- a/Billing.API/Services/Invoice/InvoiceService.cs
+++ b/Billing.API/Services/Invoice/InvoiceService.cs
@@ -90,7 +90,7 @@ namespace Billing.API.Services.Invoice
 
                     var schema = _sapServiceSettingsService.GetSapSchema("AR");
 
-                    var query = $"select * from {schema}.oeml";
+                    var query = $"select TOP 1 * from {schema}.oeml";
 
                     var da = new HanaDataAdapter(query, conn);
 
@@ -122,7 +122,7 @@ namespace Billing.API.Services.Invoice
 
                     var schema = _sapServiceSettingsService.GetSapSchema("US");
 
-                    var query = $"select * from {schema}.oeml";
+                    var query = $"select TOP 1 * from {schema}.oeml";
 
                     var da = new HanaDataAdapter(query, conn);
 


### PR DESCRIPTION
# Background
We need to fix the SQL consult for /testSap and /testSapUs  to connection test because these endpoints don't have a [authorize], so anything external agent can be disabled the Hanna database if executes many get requests